### PR TITLE
Fixing README documentation on csp_report_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SecureHeaders::Configuration.default do |config|
   config.referrer_policy = "origin-when-cross-origin"
   config.csp = {
     # "meta" values. these will shaped the header, but the values are not included in the header.
-    report_only: true,      # default: false [DEPRECATED: instead, configure csp_report_only]
+    report_only: true,      # default: false [DEPRECATED from 3.5.0: instead, configure csp_report_only]
     preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 
     # directive values: these values will directly translate into source directives
@@ -69,6 +69,7 @@ SecureHeaders::Configuration.default do |config|
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: %w(https://report-uri.io/example-csp)
   }
+  # This is available only from 3.5.0; use the `report_only: true` setting for 3.4.1 and below.
   config.csp_report_only = config.csp.merge({
     img_src: %w(somewhereelse.com),
     report_uri: %w(https://report-uri.io/example-csp-report-only)


### PR DESCRIPTION
## All PRs:
- [x] Documentation updated

`csp_report_only` is available only in 3.5.0_pre and onwards, but if you run bundle install with `gem 'secure_headers``in your Gemfile, it will pull 3.4.1 which doesn't have`csp_report_only` available.
